### PR TITLE
Add multiple ticker support

### DIFF
--- a/super_signal/cli.py
+++ b/super_signal/cli.py
@@ -7,6 +7,9 @@ with colored terminal output.
 import os
 import sys
 import logging
+from dataclasses import dataclass
+from typing import Optional, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .fetchers.yahoo_finance import fetch_stock_info, fetch_vix, is_adr_yahoo
 from .fetchers.finviz import determine_adr_status, get_directors
@@ -14,8 +17,58 @@ from .analyzers import analyze_stock_risks
 from .formatters.display import print_stock_summary
 from .formatters import get_formatter
 from .config import ANSIColor, RED_FLAGS, DISPLAY_CONFIG
+from .models import StockInfo, RiskAnalysis
 
 logger = logging.getLogger("super_signal.cli")
+
+
+@dataclass
+class TickerResult:
+    """Result of processing a single ticker.
+
+    Attributes:
+        ticker: Stock ticker symbol
+        stock_info: Stock information if successful
+        risk_analysis: Risk analysis if successful
+        error: Error message if failed
+    """
+    ticker: str
+    stock_info: Optional[StockInfo] = None
+    risk_analysis: Optional[RiskAnalysis] = None
+    error: Optional[str] = None
+
+    @property
+    def success(self) -> bool:
+        """Check if the ticker was processed successfully."""
+        return self.stock_info is not None
+
+
+def normalize_tickers(ticker_args: List[str]) -> List[str]:
+    """Normalize ticker arguments into a flat list of unique tickers.
+
+    Handles both comma-separated values and multiple -t flags.
+
+    Args:
+        ticker_args: List of ticker arguments (may contain commas)
+
+    Returns:
+        Deduplicated list of uppercase ticker symbols preserving first occurrence order
+
+    Examples:
+        >>> normalize_tickers(["AAPL,GOOG", "MSFT"])
+        ['AAPL', 'GOOG', 'MSFT']
+        >>> normalize_tickers(["AAPL", "AAPL,GOOG"])
+        ['AAPL', 'GOOG']
+    """
+    seen = set()
+    result = []
+    for arg in ticker_args:
+        for ticker in arg.split(","):
+            ticker = ticker.strip().upper()
+            if ticker and ticker not in seen:
+                seen.add(ticker)
+                result.append(ticker)
+    return result
 
 
 def clear_screen() -> None:
@@ -99,6 +152,139 @@ def run_for_ticker(ticker_symbol: str, output_format: str = "text") -> bool:
     except Exception as e:
         print(f"Error retrieving data for {ticker_symbol}: {e}", file=sys.stderr)
         logger.exception(f"Unexpected error screening {ticker_symbol}")
+        return False
+
+
+def fetch_ticker_data(ticker_symbol: str) -> TickerResult:
+    """Fetch and analyze data for a single ticker.
+
+    This is a thread-safe function that can be called in parallel.
+
+    Args:
+        ticker_symbol: Stock ticker symbol to process
+
+    Returns:
+        TickerResult with either stock_info/risk_analysis or error
+    """
+    ticker_symbol = ticker_symbol.strip().upper()
+    if not ticker_symbol:
+        return TickerResult(ticker=ticker_symbol, error="Empty ticker symbol")
+
+    try:
+        logger.info(f"Fetching data for {ticker_symbol}")
+
+        # Fetch stock info from Yahoo Finance
+        stock_info = fetch_stock_info(ticker_symbol)
+
+        if stock_info is None:
+            logger.error(f"Failed to fetch stock info for {ticker_symbol}")
+            return TickerResult(
+                ticker=ticker_symbol,
+                error="Unable to retrieve data"
+            )
+
+        # Determine ADR status
+        yahoo_adr_check = is_adr_yahoo(stock_info)
+        stock_info.is_adr = determine_adr_status(ticker_symbol, yahoo_adr_check)
+
+        # Get directors
+        stock_info.directors = get_directors(
+            ticker_symbol,
+            max_count=DISPLAY_CONFIG.directors_max_count
+        )
+
+        # Analyze risks
+        risk_analysis = analyze_stock_risks(stock_info)
+
+        logger.info(f"Successfully fetched data for {ticker_symbol}")
+        return TickerResult(
+            ticker=ticker_symbol,
+            stock_info=stock_info,
+            risk_analysis=risk_analysis
+        )
+
+    except Exception as e:
+        logger.exception(f"Error fetching data for {ticker_symbol}")
+        return TickerResult(ticker=ticker_symbol, error=str(e))
+
+
+def run_for_tickers(
+    tickers: List[str],
+    output_format: str = "text",
+    max_workers: int = 10
+) -> bool:
+    """Run stock screening for multiple tickers.
+
+    Args:
+        tickers: List of stock ticker symbols to screen
+        output_format: Output format ('text', 'json', or 'csv')
+        max_workers: Maximum number of concurrent fetches
+
+    Returns:
+        True if at least one ticker succeeded, False if all failed
+    """
+    if not tickers:
+        print("No tickers provided.", file=sys.stderr)
+        return False
+
+    # For single ticker, use original behavior for backward compatibility
+    if len(tickers) == 1:
+        return run_for_ticker(tickers[0], output_format=output_format)
+
+    try:
+        logger.info(f"Starting batch screening for {len(tickers)} tickers")
+
+        # Fetch VIX once before processing tickers
+        vix_value = fetch_vix()
+
+        # Fetch ticker data in parallel, preserving order
+        results: List[TickerResult] = []
+        ticker_to_index = {t: i for i, t in enumerate(tickers)}
+
+        with ThreadPoolExecutor(max_workers=min(max_workers, len(tickers))) as executor:
+            future_to_ticker = {
+                executor.submit(fetch_ticker_data, ticker): ticker
+                for ticker in tickers
+            }
+
+            # Collect results as they complete
+            result_map = {}
+            for future in as_completed(future_to_ticker):
+                ticker = future_to_ticker[future]
+                try:
+                    result = future.result()
+                    result_map[ticker] = result
+                except Exception as e:
+                    logger.exception(f"Unexpected error processing {ticker}")
+                    result_map[ticker] = TickerResult(ticker=ticker, error=str(e))
+
+        # Reorder results to match original ticker order
+        results = [result_map[t] for t in tickers]
+
+        # Format and display results using batch formatter
+        formatter = get_formatter(output_format)
+        output = formatter.format_batch(
+            results,
+            RED_FLAGS.min_free_float,
+            vix_value
+        )
+        print(output)
+
+        # Return True if at least one ticker succeeded
+        successes = sum(1 for r in results if r.success)
+        logger.info(
+            f"Batch screening complete: {successes}/{len(tickers)} succeeded"
+        )
+        return successes > 0
+
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user.", file=sys.stderr)
+        logger.info("User cancelled batch operation")
+        return False
+
+    except Exception as e:
+        print(f"Error during batch processing: {e}", file=sys.stderr)
+        logger.exception("Unexpected error in batch screening")
         return False
 
 

--- a/super_signal/main.py
+++ b/super_signal/main.py
@@ -32,8 +32,11 @@ def parse_arguments():
     parser.add_argument(
         "--ticker",
         "-t",
-        type=str,
-        help="Ticker symbol to screen (skips interactive mode)"
+        action="append",
+        dest="tickers",
+        metavar="TICKER",
+        help="Ticker symbol(s) to screen. Can be specified multiple times "
+             "(-t AAPL -t GOOG) or comma-separated (-t AAPL,GOOG)"
     )
 
     parser.add_argument(
@@ -72,10 +75,11 @@ def main():
 
     # Launch CLI interface
     try:
-        if args.ticker:
-            # Single ticker mode
-            from .cli import run_for_ticker
-            success = run_for_ticker(args.ticker, output_format=args.format)
+        if args.tickers:
+            # Ticker mode (single or multiple)
+            from .cli import run_for_tickers, normalize_tickers
+            tickers = normalize_tickers(args.tickers)
+            success = run_for_tickers(tickers, output_format=args.format)
             sys.exit(0 if success else 1)
         else:
             # Interactive mode (always uses text format)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for CLI functions."""
+
+import pytest
+
+from super_signal.cli import normalize_tickers, TickerResult
+from super_signal.models import StockInfo, RiskAnalysis
+
+
+class TestNormalizeTickers:
+    """Tests for the normalize_tickers function."""
+
+    def test_single_ticker(self):
+        """Test with a single ticker."""
+        result = normalize_tickers(["AAPL"])
+        assert result == ["AAPL"]
+
+    def test_multiple_tickers_separate_args(self):
+        """Test with multiple tickers as separate arguments."""
+        result = normalize_tickers(["AAPL", "GOOG", "MSFT"])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_comma_separated_tickers(self):
+        """Test with comma-separated tickers in a single argument."""
+        result = normalize_tickers(["AAPL,GOOG,MSFT"])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_mixed_format(self):
+        """Test with mixed format (comma-separated and separate args)."""
+        result = normalize_tickers(["AAPL,GOOG", "MSFT"])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_uppercase_conversion(self):
+        """Test that lowercase tickers are converted to uppercase."""
+        result = normalize_tickers(["aapl", "goog"])
+        assert result == ["AAPL", "GOOG"]
+
+    def test_deduplication(self):
+        """Test that duplicate tickers are removed."""
+        result = normalize_tickers(["AAPL", "GOOG", "AAPL"])
+        assert result == ["AAPL", "GOOG"]
+
+    def test_deduplication_comma_separated(self):
+        """Test that duplicate tickers in comma-separated format are removed."""
+        result = normalize_tickers(["AAPL,GOOG,AAPL"])
+        assert result == ["AAPL", "GOOG"]
+
+    def test_deduplication_across_args(self):
+        """Test that duplicate tickers across arguments are removed."""
+        result = normalize_tickers(["AAPL,GOOG", "GOOG,MSFT"])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_preserves_order(self):
+        """Test that first occurrence order is preserved."""
+        result = normalize_tickers(["MSFT", "AAPL", "GOOG"])
+        assert result == ["MSFT", "AAPL", "GOOG"]
+
+    def test_whitespace_handling(self):
+        """Test that whitespace is stripped."""
+        result = normalize_tickers(["  AAPL  ", " GOOG , MSFT "])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_empty_string_filtered(self):
+        """Test that empty strings are filtered out."""
+        result = normalize_tickers(["AAPL", "", "GOOG"])
+        assert result == ["AAPL", "GOOG"]
+
+    def test_empty_after_comma_filtered(self):
+        """Test that empty parts after comma split are filtered."""
+        result = normalize_tickers(["AAPL,,GOOG", "MSFT,"])
+        assert result == ["AAPL", "GOOG", "MSFT"]
+
+    def test_empty_list(self):
+        """Test with empty input list."""
+        result = normalize_tickers([])
+        assert result == []
+
+
+class TestTickerResult:
+    """Tests for the TickerResult dataclass."""
+
+    def test_success_property_true(self):
+        """Test success property returns True when stock_info is present."""
+        stock_info = StockInfo(ticker="AAPL")
+        risk_analysis = RiskAnalysis(ticker="AAPL")
+        result = TickerResult(
+            ticker="AAPL",
+            stock_info=stock_info,
+            risk_analysis=risk_analysis
+        )
+        assert result.success is True
+
+    def test_success_property_false(self):
+        """Test success property returns False when stock_info is None."""
+        result = TickerResult(ticker="INVALID", error="Unable to retrieve data")
+        assert result.success is False
+
+    def test_success_property_false_with_none(self):
+        """Test success property returns False when all optional fields are None."""
+        result = TickerResult(ticker="EMPTY")
+        assert result.success is False
+
+    def test_error_field(self):
+        """Test error field stores error message."""
+        error_msg = "Unable to retrieve data"
+        result = TickerResult(ticker="INVALID", error=error_msg)
+        assert result.error == error_msg
+        assert result.success is False


### PR DESCRIPTION
## Summary
- Add support for processing multiple tickers in a single command
- Multiple `-t` flags: `-t AAPL -t GOOG -t MSFT`
- Comma-separated: `-t AAPL,GOOG,MSFT`
- Mixed: `-t AAPL,GOOG -t MSFT`
- Parallel fetching with ThreadPoolExecutor (max 10 workers)
- Format-specific batch output for text, JSON, and CSV

## Test plan
- [x] All 267 tests pass
- [ ] Test single ticker backward compatibility: `python -m super_signal -t AAPL`
- [ ] Test multiple tickers: `python -m super_signal -t AAPL,GOOG,MSFT`
- [ ] Test JSON format: `python -m super_signal -t AAPL,GOOG -f json | python -m json.tool`
- [ ] Test CSV format: `python -m super_signal -t AAPL,GOOG -f csv`
- [ ] Test error handling: `python -m super_signal -t AAPL,INVALIDTICKER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)